### PR TITLE
Add evm account address check & messages for SORA->ETH direction

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -543,7 +543,9 @@
         "confirm": "@:confirmTransactionText",
         "newTransaction": "Create new transaction",
         "changeNetwork": "@:changeNetworkText",
-        "connectWallet": "@:connectWalletText"
+        "connectWallet": "@:connectWalletText",
+        "changeAccount": "@:changeAccountText in @:metamask",
+        "expectedAddress": "Expected address in @:metamask"
     },
     "months": {
         "0": "Jan",

--- a/src/lang/messages.ts
+++ b/src/lang/messages.ts
@@ -373,7 +373,9 @@ export default {
     confirm: '@:confirmTransactionText',
     newTransaction: 'Create new transaction',
     changeNetwork: '@:changeNetworkText',
-    connectWallet: '@:connectWalletText'
+    connectWallet: '@:connectWalletText',
+    changeAccount: '@:changeAccountText in @:metamask',
+    expectedAddress: 'Expected address in @:metamask'
   },
   months: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
   bridgeHistory: {

--- a/src/utils/fsm.ts
+++ b/src/utils/fsm.ts
@@ -377,9 +377,12 @@ function createFSM (context: Context, states, initialState = STATES.INITIAL) {
       }),
       [ACTIONS.SET_SORA_TRANSACTION_HASH]: assign({
         history: (context, event) => {
+          if (!event.data) return context.history
+
           return ({
             ...context.history,
-            hash: event.data
+            hash: event.data.hash,
+            to: event.data.to
           })
         }
       }),

--- a/src/views/BridgeTransaction.vue
+++ b/src/views/BridgeTransaction.vue
@@ -90,6 +90,10 @@
                 <span v-if="isTransactionStep2" :class="transactionIconStatusClasses(true)" />
               </div>
             </template>
+            <div v-if="isSoraToEvm && !isTxEvmAccount" class="transaction-error">
+              <span class="transaction-error__title">Expected address in MetaMask:</span>
+              <span class="transaction-error__value">{{ transactionEvmAddress }}</span>
+            </div>
             <div v-if="isTransactionStep2 && transactionToHash" :class="hashContainerClasses(isSoraToEvm)">
               <s-input :placeholder="t('bridgeTransaction.transactionHash')" :value="formatTxHash(transactionToHash)" readonly />
               <s-button class="s-button--hash-copy" type="action" alternative icon="basic-copy-24" @click="handleCopyTransactionHash(transactionToHash)" />
@@ -128,10 +132,11 @@
               v-if="isTransactionStep2 && !isTransferCompleted"
               type="primary"
               class="s-typograhy-button--big"
-              :disabled="(isSoraToEvm && !isValidNetworkType) || isInsufficientXorForFee || isInsufficientEvmNativeTokenForFee || isTransactionToPending"
+              :disabled="(isSoraToEvm && (!isValidNetworkType || !isTxEvmAccount)) || isInsufficientXorForFee || isInsufficientEvmNativeTokenForFee || isTransactionToPending"
               @click="handleSendTransactionTo"
             >
               <template v-if="isSoraToEvm && !isExternalAccountConnected">{{ t('bridgeTransaction.connectWallet') }}</template>
+              <template v-else-if="isSoraToEvm && !isTxEvmAccount">{{ t('bridgeTransaction.changeAccount') }}</template>
               <template v-else-if="isSoraToEvm && !isValidNetworkType">{{ t('bridgeTransaction.changeNetwork') }}</template>
               <span v-else-if="isTransactionToPending" v-html="t('bridgeTransaction.pending', { network: t(`bridgeTransaction.${!isSoraToEvm ? 'sora' : 'ethereum'}`) })" />
               <template v-else-if="isInsufficientXorForFee">{{ t('confirmBridgeTransactionDialog.insufficientBalance', { assetSymbol : KnownSymbols.XOR }) }}</template>
@@ -205,6 +210,7 @@ export default class BridgeTransaction extends Mixins(
   @Getter('initialTransactionState', { namespace }) initialTransactionState!: STATES
   @Getter('transactionStep', { namespace }) transactionStep!: number
   @Getter('historyItem', { namespace }) historyItem!: any
+  @Getter('isTxEvmAccount', { namespace }) isTxEvmAccount!: boolean
 
   @Action('getNetworkFee', { namespace }) getNetworkFee!: AsyncVoidFn
 
@@ -372,6 +378,10 @@ export default class BridgeTransaction extends Mixins(
       return this.t('bridgeTransaction.statuses.done')
     }
     return this.t('bridgeTransaction.statuses.waitingForConfirmation')
+  }
+
+  get transactionEvmAddress (): string {
+    return this.historyItem?.to ?? ''
   }
 
   get soraTxId (): Nullable<string> {
@@ -849,6 +859,20 @@ $collapse-header-height: calc(#{$basic-spacing * 4} + #{$collapse-header-title-h
       width: var(--s-size-mini);
       height: var(--s-size-mini);
       line-height: 1;
+    }
+  }
+  &-error {
+    color: var(--s-color-status-error);
+    display: flex;
+    flex-flow: column nowrap;
+    padding: 0 $inner-spacing-mini / 2;
+    margin-bottom: $inner-spacing-mini;
+
+    &__title {
+      text-transform: uppercase;
+    }
+    &__value {
+      font-weight: 600;
     }
   }
 }


### PR DESCRIPTION
# Task

[PW-129]: ETH Bridge. Changing MetaMask account causes a crash of transaction.

1. Saved 'to' field to bridge history item (evm account address)
2. Show button message "Change account in MetaMask" when account is not match the address in tx, and expected account address in MetaMask
3. Waiting for approval sora tx (Sora -> Eth) in ui at first step

![transaction-address-4](https://user-images.githubusercontent.com/53777036/126153855-55526eb3-3d68-471b-9c7f-324aacca489d.jpg)

[PW-129]: https://soramitsu.atlassian.net/browse/PW-129