### PR TITLE
PW-355: Wrong $ amount at strategic rewards for PSWAP

### DIFF
--- a/src/views/Rewards.vue
+++ b/src/views/Rewards.vue
@@ -26,6 +26,7 @@
                 :item="vestedRewadsGroupItem"
                 :theme="libraryTheme"
                 :disabled="!vestedRewardsAvailable"
+                is-codec-string
               />
               <rewards-amount-table
                 class="rewards-table"
@@ -188,7 +189,7 @@ export default class Rewards extends Mixins(FormattedAmountMixin, WalletConnectM
       type: this.t('rewards.groups.strategic'),
       title: this.t('rewards.claimableAmountDoneVesting'),
       limit: [{
-        amount: FPNumber.fromCodecValue(this.vestedRewards?.limit ?? 0, pswap.decimals).toLocaleString(),
+        amount: FPNumber.fromCodecValue(this.vestedRewards?.limit ?? 0, pswap.decimals).toCodecString(),
         asset: pswap
       }],
       total: {


### PR DESCRIPTION
# Task

[PW-355]: Wrong $ amount at strategic rewards for PSWAP

## Changes

* Rewards: Fixed fiat value error.

[PW-355]: https://soramitsu.atlassian.net/browse/PW-355