### PR TITLE
Use extended ubuntu 14 dockerImage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 def pipeline = new org.js.AppPipeline(steps: this,
     dockerImageName: 'polkaswap/exchange-web',
-    buildDockerImage: 'docker.soramitsu.co.jp/build-tools/node:14-ubuntu',
+    buildDockerImage: 'docker.soramitsu.co.jp/build-tools/node:14-ubuntu-extended',
     dockerRegistryCred: 'bot-polkaswap-rw',
     pushToIPFS: true)
 pipeline.runPipeline()


### PR DESCRIPTION
Signed-off-by: Ahmed Elkashef <elkashef@soramitsu.co.jp>

# Task

Use the extended ubuntu-14 Docker Image.

## Changes

1. Use the extended ubuntu-14 Docker Image.