### PR TITLE
add plugin & adjust config

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "ts-jest": "^27.0.5",
     "typescript": "~4.4.4",
     "vue-cli-plugin-electron-builder": "^3.0.0-alpha.3",
+    "vue-cli-plugin-test-attrs": "^0.1.5",
     "vue-svg-loader": "^0.16.0",
     "vue-template-compiler": "^2.6.14"
   },

--- a/vue.config.js
+++ b/vue.config.js
@@ -31,32 +31,34 @@ module.exports = {
   chainWebpack: (config) => {
     const svgRule = config.module.rule('svg');
     svgRule.uses.clear();
-    config.module.rule('svg')
+    config.module
+      .rule('svg')
       .oneOf('inline-svg')
-        .resourceQuery(/inline/)
-        .use('babel')
-          .loader('babel-loader')
-        .end()
-        .use('vue-svg-loader')
-          .loader('vue-svg-loader')
-        .end()
+      .resourceQuery(/inline/)
+      .use('babel')
+      .loader('babel-loader')
+      .end()
+      .use('vue-svg-loader')
+      .loader('vue-svg-loader')
+      .end()
       .end()
       .oneOf('file')
-        .use('file-loader')
-          .loader('file-loader')
-        .end()
+      .use('file-loader')
+      .loader('file-loader')
+      .end()
       .end();
 
     // https://webpack.js.org/guides/asset-modules/
     const imagesRule = config.module.rule('images');
     imagesRule.uses.clear();
-    config.module.rule('images')
+    config.module
+      .rule('images')
       .oneOf('asset-inline')
-        .resourceQuery(/inline/)
-        .type('asset/inline')
+      .resourceQuery(/inline/)
+      .type('asset/inline')
       .end()
       .oneOf('asset')
-        .type('asset')
+      .type('asset')
       .end();
   },
   /* eslint-enable */
@@ -70,6 +72,11 @@ module.exports = {
           @import "@/styles/_typography.scss";
         `,
       },
+    },
+  },
+  pluginOptions: {
+    testAttrs: {
+      attrs: ['test', 'testid', 'test-name'],
     },
   },
   productionSourceMap: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15143,6 +15143,11 @@ vue-cli-plugin-electron-builder@^3.0.0-alpha.3:
     webpack-merge "^5.8.0"
     yargs "^16.2.0"
 
+vue-cli-plugin-test-attrs@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/vue-cli-plugin-test-attrs/-/vue-cli-plugin-test-attrs-0.1.5.tgz#afd0cd676a6d218cfc8fc32fc8b64faf43197c03"
+  integrity sha512-SbxNpPOQ3KIBJVr9Ihf3cxbN9RyXu5g747RdadIkBAP5HLFLQrKePKXxBDUK5Z+DPSe6jxPNVPIJiLJbp1A2TQ==
+
 vue-eslint-parser@^7.0.0, vue-eslint-parser@^7.10.0:
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-7.11.0.tgz#214b5dea961007fcffb2ee65b8912307628d0daf"


### PR DESCRIPTION
This commit will remove data-test attributes specified in vue.config.js -> testAttrs array -> ['test', 'testid', 'test-name'], meaning, these combinations:
1) `data-test="..."`
2) `data-testid="..."`
3) `data-test-name="..."`
for production (yarn build) and local development (yarn serve)
