### PR TITLE
[PW-709] Remove initial sync with metamask on page loading

### DIFF
--- a/src/components/Moonpay/MoonpayBridgeInitMixin.ts
+++ b/src/components/Moonpay/MoonpayBridgeInitMixin.ts
@@ -47,7 +47,6 @@ export default class MoonpayBridgeInitMixin extends Mixins(BridgeHistoryMixin, W
   async prepareEvmNetwork(networkId = BridgeNetworks.ETH_NETWORK_ID): Promise<void> {
     this.setEvmNetwork(networkId); // WalletConnectMixin
     await this.setEvmNetworkType(); // WalletConnectMixin
-    await this.syncExternalAccountWithAppState(); // WalletConnectMixin
   }
 
   initMoonpayApi(): void {

--- a/src/components/mixins/SubscriptionsMixin.ts
+++ b/src/components/mixins/SubscriptionsMixin.ts
@@ -25,12 +25,12 @@ export default class SubscriptionsMixin extends Mixins(mixins.LoadingMixin) {
     return this.parentLoading || this.loading;
   }
 
-  async mounted(): Promise<void> {
-    await this.updateSubscriptions();
+  mounted(): void {
+    this.updateSubscriptions();
   }
 
-  async beforeDestroy(): Promise<void> {
-    await this.resetSubscriptions();
+  beforeDestroy(): void {
+    this.resetSubscriptions();
   }
 
   public setStartSubscriptions(list: AsyncVoidFn[]) {

--- a/src/components/mixins/WalletConnectMixin.ts
+++ b/src/components/mixins/WalletConnectMixin.ts
@@ -129,16 +129,4 @@ export default class WalletConnectMixin extends Mixins(TranslationMixin) {
     this.resetEvmAddress();
     this.resetWeb3Store();
   }
-
-  async syncExternalAccountWithAppState(): Promise<void> {
-    try {
-      const connected = await ethersUtil.checkAccountIsConnected(this.evmAddress);
-
-      if (!connected && this.evmAddress) {
-        this.disconnectExternalAccount();
-      }
-    } catch (error) {
-      this.disconnectExternalAccount();
-    }
-  }
 }

--- a/src/views/BridgeContainer.vue
+++ b/src/views/BridgeContainer.vue
@@ -31,8 +31,6 @@ export default class BridgeContainer extends Mixins(mixins.LoadingMixin, WalletC
 
   async created(): Promise<void> {
     await this.withLoading(async () => {
-      await this.syncExternalAccountWithAppState();
-
       await this.withParentLoading(async () => {
         this.setEvmNetwork(bridgeApi.externalNetwork);
         await this.onEvmNetworkTypeChange();


### PR DESCRIPTION
# Task

[PW-709]: The user cannot see the page data until he logs into Metamask