### PR TITLE
Fix router warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@metamask/detect-provider": "^1.2.0",
-    "@soramitsu/soraneo-wallet-web": "^1.10.4",
+    "@soramitsu/soraneo-wallet-web": "^1.10.5",
     "@walletconnect/web3-provider": "^1.6.6",
     "core-js": "^3.6.4",
     "direct-vuex": "^0.12.1",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -75,7 +75,6 @@ const routes: Array<RouteConfig> = [
   },
   {
     path: '/pool',
-    name: PageNames.PoolContainer,
     component: lazyView(PageNames.PoolContainer),
     children: [
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2391,10 +2391,10 @@
     vuex "^3.1.3"
     vuex-class "^0.3.2"
 
-"@soramitsu/soraneo-wallet-web@^1.10.4":
-  version "1.10.4"
-  resolved "https://nexus.iroha.tech/repository/npm-group/@soramitsu/soraneo-wallet-web/-/soraneo-wallet-web-1.10.4.tgz#d24e88dc9e5013acc6808966ca7109e63bd0936f"
-  integrity sha512-UW/U+d+UqWZdhl90K42H5Mbp/+DI7mVOG7gE0mKxOitxSeRLRcYgR9AJDqFbCRJL4upVt8KOe9w/9Wr8KUDCMQ==
+"@soramitsu/soraneo-wallet-web@^1.10.5":
+  version "1.10.5"
+  resolved "https://nexus.iroha.tech/repository/npm-group/@soramitsu/soraneo-wallet-web/-/soraneo-wallet-web-1.10.5.tgz#145a99393b1a2d3ec3c77c435578f42db34e874e"
+  integrity sha512-6KFsXlB1mGnGK6aTjloRJFD+2cpQueJbXxudat5yC9V28tLw8LoJ1lRp7A2OfBDXxwwTpyQxtTilgNFQcConRw==
   dependencies:
     "@polkadot/vue-identicon" "2.6.1"
     "@sora-substrate/util" "1.10.0-beta.6"


### PR DESCRIPTION
# Task

[vue-router] Named Route 'PoolContainer' has a default child route. When navigating to this named route (:to="{name: 'PoolContainer'"), the default child route will not be rendered. Remove the name from this route and use the name of the default child route for named links instead.

## Changes

1. Fix router warning.