### PR TITLE
Fix Demeters dialogs bottom padding

### DIFF
--- a/src/modules/demeterFarming/components/CalculatorDialog.vue
+++ b/src/modules/demeterFarming/components/CalculatorDialog.vue
@@ -265,6 +265,8 @@ export default class CalculatorDialog extends Mixins(PoolCardMixin, mixins.Dialo
 
 <style lang="scss" scoped>
 .calculator-dialog {
+  padding-bottom: $inner-spacing-medium;
+
   & > *:not(:first-child) {
     margin-top: $inner-spacing-medium;
   }

--- a/src/modules/demeterFarming/components/ClaimDialog.vue
+++ b/src/modules/demeterFarming/components/ClaimDialog.vue
@@ -83,6 +83,8 @@ export default class ClaimDialog extends Mixins(
 .claim-dialog {
   @include full-width-button('action-button');
 
+  padding-bottom: $inner-spacing-medium;
+
   & > *:not(:last-child) {
     margin-top: $inner-spacing-medium;
   }

--- a/src/modules/demeterFarming/components/StakeDialog.vue
+++ b/src/modules/demeterFarming/components/StakeDialog.vue
@@ -299,6 +299,8 @@ export default class StakeDialog extends Mixins(PoolCardMixin, mixins.DialogMixi
 .stake-dialog {
   @include full-width-button('action-button');
 
+  padding-bottom: $inner-spacing-medium;
+
   & > *:not(:first-child) {
     margin-top: $inner-spacing-medium;
   }


### PR DESCRIPTION
This PR fixes bottom padding in all 3 Demeters dialogs:
1) Staking;
2) Claiming/removing;
3) Calculator.

Example:
![image](https://user-images.githubusercontent.com/2076748/226502648-0024e13c-9ea7-478e-a7ed-3a5e5e96b6f9.png)
