### PR TITLE
z-index updated

### DIFF
--- a/src/components/App/Menu/AppMenu.vue
+++ b/src/components/App/Menu/AppMenu.vue
@@ -405,6 +405,7 @@ export default class AppMenu extends Mixins(TranslationMixin) {
     @include large-mobile(true) {
       position: fixed;
       right: 0;
+      z-index: $app-above-loader-layer;
 
       &.visible {
         visibility: visible;


### PR DESCRIPTION
# Task

[PW-1614]: Mobile menu is overlapped by page content while page is loading.

## Changes

1. Description.
[PW-1614]: https://soramitsu.atlassian.net/browse/PW-1614