### PR TITLE
Remove dirty hack for dialog re-center

### DIFF
--- a/src/components/App/Alerts/AlertList.vue
+++ b/src/components/App/Alerts/AlertList.vue
@@ -124,13 +124,6 @@ export default class AlertList extends Mixins(
     return `${priceChangeFormatted}% · ${this.t('alerts.currentPrice')}: $${currentPriceFormatted}`;
   }
 
-  /** Re-center dialog programmatically (need to simplify it). Components lazy loading might break it */
-  private async recenterDialog(): Promise<void> {
-    await this.$nextTick();
-    const sDialog: any = this.$parent?.$parent;
-    sDialog?.computeTop?.();
-  }
-
   /** Force close menu if it wasn't closed */
   private forceCloseAlertMenu(index: number): void {
     this.$refs['alertMenu' + index]?.[0]?.doClose?.();
@@ -152,7 +145,6 @@ export default class AlertList extends Mixins(
   handleDeleteAlert(position: number): void {
     this.removePriceAlert(position);
     this.forceCloseAlertMenu(position);
-    this.recenterDialog();
     this.scrollForceUpdate();
   }
 
@@ -167,8 +159,6 @@ export default class AlertList extends Mixins(
   }
 
   mounted(): void {
-    this.recenterDialog();
-
     if (Notification.permission !== 'granted') {
       this.setDepositNotifications(false);
     }

--- a/src/components/App/Alerts/CreateAlert.vue
+++ b/src/components/App/Alerts/CreateAlert.vue
@@ -225,11 +225,6 @@ export default class CreateAlert extends Mixins(
   }
 
   async mounted(): Promise<void> {
-    // Re-center dialog programmatically (need to simplify it). Components lazy loading might break it
-    await this.$nextTick();
-    const sDialog: any = this.$parent?.$parent;
-    sDialog?.computeTop?.();
-
     if (this.isEditMode) {
       this.amount = this.alertToEdit.price;
       this.currentTypeTab = this.alertToEdit.type === 'drop' ? AlertTypeTabs.Drop : AlertTypeTabs.Raise;

--- a/src/components/App/Settings/Node/NodeInfo.vue
+++ b/src/components/App/Settings/Node/NodeInfo.vue
@@ -137,10 +137,6 @@ export default class NodeInfo extends Mixins(TranslationMixin) {
   }
 
   async mounted(): Promise<void> {
-    // Re-center dialog programmatically (need to simplify it). Components lazy loading might break it
-    await this.$nextTick();
-    const sDialog: any = this.$parent?.$parent;
-    sDialog?.computeTop?.();
     // Focus first element if inputs are editable
     if (!this.inputDisabled) {
       this.nodeNameInput?.focus?.();

--- a/src/components/App/Settings/Node/SelectNode.vue
+++ b/src/components/App/Settings/Node/SelectNode.vue
@@ -89,13 +89,6 @@ export default class SelectNode extends Mixins(TranslationMixin) {
   reconnect(node: Node) {
     this.$emit('input', node.address);
   }
-
-  async mounted(): Promise<void> {
-    // Re-center dialog programmatically (need to simplify it). Components lazy loading might break it
-    await this.$nextTick();
-    const sDialog: any = this.$parent?.$parent;
-    sDialog?.computeTop?.();
-  }
 }
 </script>
 


### PR DESCRIPTION
### **Description**
- **What does this PR do?**
  - _Removed dirty hack for dialog re-center because the base dialog component was already improved so there is no need for that hack anymore_
  
- **Why is this change needed?**
  - _To remove doubled source code_

### **Type of change**
- [ ] Bug fix
- [ ] New feature
- [x] Refactor (cleaning up code without changing functionality)
- [ ] Documentation update
- [ ] Tests
- [ ] Other (describe below):

---

### **Checklist**
- [x] Code adheres to coding guidelines and standards.
- [x] Linting and formatting checks have passed, no local issues.
- [x] Existing tests pass successfully, no local errors.
- [x] Pull request is linked to a relevant issue or task.
- [ ] Tests are written for new features or fixes.
- [ ] Documentation has been updated (if applicable).
  
---

### **Related Issue/Task**
- [Related PW-1749 issue](https://soramitsu.atlassian.net/browse/PW-1749)

---

### **Testing**
- **How has this been tested?**
  - _Check it using any of modal dialog with dynamic content_

### **Reviewer Tasks**
- [ ] Review logic for correctness and clarity.
- [ ] Verify that the code is following best practices.
- [ ] Test or review related areas if this PR affects other projects.
