### PR TITLE
Fix base & quote symbols for TX Details in Orderbook

### DIFF
--- a/src/components/pages/OrderBook/TransactionDetails.vue
+++ b/src/components/pages/OrderBook/TransactionDetails.vue
@@ -114,11 +114,11 @@ export default class PlaceTransactionDetails extends Mixins(mixins.FormattedAmou
     return this.isBuy ? this.quoteSymbol : this.baseSymbol;
   }
 
-  get total(): FPNumber {
+  private get total(): FPNumber {
     return this.getFPNumber(this.baseValue).mul(this.getFPNumber(this.quoteValue));
   }
 
-  get isBuy(): boolean {
+  private get isBuy(): boolean {
     return this.side === PriceVariant.Buy;
   }
 

--- a/src/components/pages/OrderBook/TransactionDetails.vue
+++ b/src/components/pages/OrderBook/TransactionDetails.vue
@@ -4,7 +4,7 @@
       :label="t('orderBook.txDetails.orderType')"
       :label-tooltip="t('orderBook.tooltip.txDetails.orderType')"
       :value="sideText"
-      :class="getComputedClass()"
+      :class="computedClass"
     />
     <info-line
       :label="t('orderBook.txDetails.limitPrice')"
@@ -132,14 +132,11 @@ export default class PlaceTransactionDetails extends Mixins(mixins.FormattedAmou
     return this.formatCodecNumber(this.networkFee);
   }
 
-  formatFee(fee: string, formattedFee: string): string {
-    return fee !== ZeroStringValue ? formattedFee : ZeroStringValue;
-  }
-
-  getComputedClass(): string | undefined {
+  get computedClass(): string | undefined {
     if (this.infoOnly) {
       return this.side === PriceVariant.Buy ? 'limit-order-type--buy' : 'limit-order-type--sell';
     }
+    return undefined;
   }
 }
 </script>

--- a/src/components/pages/OrderBook/TransactionDetails.vue
+++ b/src/components/pages/OrderBook/TransactionDetails.vue
@@ -69,13 +69,11 @@ import type { AccountAsset } from '@sora-substrate/sdk/build/assets/types';
 export default class PlaceTransactionDetails extends Mixins(mixins.FormattedAmountMixin, TranslationMixin) {
   @state.orderBook.baseValue baseValue!: string;
   @state.orderBook.quoteValue quoteValue!: string;
-  @state.orderBook.baseAssetAddress baseAssetAddress!: string;
-  @state.orderBook.quoteAssetAddress quoteAssetAddress!: string;
   @state.orderBook.side side!: PriceVariant;
   @state.swap.toValue toValue!: string;
   @state.wallet.settings.networkFees private networkFees!: NetworkFeesObject;
-
-  @getter.assets.assetDataByAddress getAsset!: (addr?: string) => AccountAsset;
+  @getter.orderBook.baseAsset private baseAsset!: AccountAsset;
+  @getter.orderBook.quoteAsset private quoteAsset!: AccountAsset;
 
   @Prop({ default: true, type: Boolean }) readonly infoOnly!: boolean;
   @Prop({ default: false, type: Boolean }) readonly isMarketType!: boolean;
@@ -84,12 +82,12 @@ export default class PlaceTransactionDetails extends Mixins(mixins.FormattedAmou
     return this.networkFees[Operation.OrderBookPlaceLimitOrder];
   }
 
-  get baseSymbol(): string | undefined {
-    return this.getAsset(this.baseAssetAddress)?.symbol;
+  get baseSymbol(): string {
+    return this.baseAsset.symbol;
   }
 
   get quoteSymbol(): string {
-    return XOR.symbol;
+    return this.quoteAsset.symbol;
   }
 
   get sideText(): string {
@@ -105,7 +103,7 @@ export default class PlaceTransactionDetails extends Mixins(mixins.FormattedAmou
   }
 
   get lockedAsset(): AccountAsset {
-    return this.isBuy ? this.getAsset(this.quoteAssetAddress) : this.getAsset(this.baseAssetAddress);
+    return this.isBuy ? this.quoteAsset : this.baseAsset;
   }
 
   get lockedAssetSymbol(): string | undefined {

--- a/src/components/pages/OrderBook/TransactionDetails.vue
+++ b/src/components/pages/OrderBook/TransactionDetails.vue
@@ -38,7 +38,7 @@
       :label="t('networkFeeText')"
       :label-tooltip="t('networkFeeTooltipText')"
       :value="formattedNetworkFee"
-      :asset-symbol="quoteSymbol"
+      :asset-symbol="xorSymbol"
       :fiat-value="getFiatAmountByCodecString(networkFee)"
       is-formatted
     />
@@ -77,6 +77,10 @@ export default class PlaceTransactionDetails extends Mixins(mixins.FormattedAmou
 
   @Prop({ default: true, type: Boolean }) readonly infoOnly!: boolean;
   @Prop({ default: false, type: Boolean }) readonly isMarketType!: boolean;
+
+  get xorSymbol(): string {
+    return XOR.symbol;
+  }
 
   get networkFee(): CodecString {
     return this.networkFees[Operation.OrderBookPlaceLimitOrder];


### PR DESCRIPTION
### **Description**
- **What does this PR do?**
  - _I've fixed base & quote symbols for TX Details in Orderbook_
  
- **Why is this change needed?**
  - _To show correct info in Orderbook TX Details Widget_

### **Type of change**
- [x] Bug fix
- [ ] New feature
- [ ] Refactor (cleaning up code without changing functionality)
- [ ] Documentation update
- [ ] Tests
- [ ] Other (describe below):

---

### **Checklist**
- [x] Code adheres to coding guidelines and standards.
- [x] Linting and formatting checks have passed, no local issues.
- [x] Existing tests pass successfully, no local errors.
- [x] Pull request is linked to a relevant issue or task.
- [ ] Tests are written for new features or fixes.
- [ ] Documentation has been updated (if applicable).
  
---

### **Related Issue/Task**
- _[Issue](https://soramitsu.atlassian.net/browse/PW-1795)_

---

### **Testing**
- **How has this been tested?**
  - _Verify the correct symbols from the screenshot below_
 
---

### **Screenshots/Video/Link to dedicated environment (if applicable)**

<img width="512" alt="image" src="https://github.com/user-attachments/assets/869b0fe7-977c-41cc-bfc2-5cb0306ff513">

---

### **Reviewer Tasks**
- [ ] Review logic for correctness and clarity.
- [ ] Verify that the code is following best practices.
- [ ] Test or review related areas if this PR affects other projects.
